### PR TITLE
Update Italian translation

### DIFF
--- a/Localization/ITA/Data/Translations/ClassicsPatch_Core.txt
+++ b/Localization/ITA/Data/Translations/ClassicsPatch_Core.txt
@@ -1,4 +1,4 @@
-181
+183
 
 \0\<
 Cannot find '%s' symbol in '%s'!
@@ -962,7 +962,7 @@ non connesso\n
 %d controller slots:\n
 
 \0\>
-%d slot controller:\n
+%d slot per controller:\n
 
 \0\<
 Connected '%s' to controller slot %d\n
@@ -981,5 +981,17 @@ Cannot open another game controller due to all %d slots being occupied!\n
 
 \0\>
 Impossibile utilizzare un altro controller di gioco poiché tutti i %d slot sono occupati!\n
+
+\0\<
+  Extension: %s\n
+
+\0\>
+  Estensione: %s\n
+
+\0\<
+(for level format %d)\n
+
+\0\>
+(per formato livello %d)\n
 
 \0\$

--- a/Localization/ITA/Data/Translations/ClassicsPatch_Mod.txt
+++ b/Localization/ITA/Data/Translations/ClassicsPatch_Mod.txt
@@ -1,4 +1,4 @@
-27
+28
 
 \0\<
 Cannot load game theme config '%s':\n
@@ -124,4 +124,10 @@ Il Golem di Terra ha seppellito %s
 %s was killed by an elemental
 \0\>
 %s è stato ucciso da un elementale
+\0\<
+Squirrel scripts are unavailable!\n
+
+\0\>
+Gli script Squirrel non sono disponibili!\n
+
 \0\$

--- a/Localization/ITA/Data/Translations/ClassicsPatch_Scripts.txt
+++ b/Localization/ITA/Data/Translations/ClassicsPatch_Scripts.txt
@@ -1,4 +1,4 @@
-576
+579
 
 \0\<
 Common options
@@ -2295,7 +2295,7 @@ Barre di scorrimento moderne
 \0\<
 replace "Page Up" and "Page Down" buttons with proper scrollbars
 \0\>
-sostituisce i tasti "Pagina Su" e "Pagina Giù" con barre di scorrimento adeguate
+sostituisce i tasti "Pagina Su" e "Pagina Giù" con barre di scorrimento
 \0\<
 Adjust mip factor of models
 \0\>
@@ -2304,4 +2304,16 @@ Regola fattore distanza modelli
 allow static models to fade into the distance for optimization purposes
 \0\>
 consente ai modelli statici di svanire in lontananza per scopi di ottimizzazione
+\0\<
+Extended Input
+\0\>
+Input esteso
+\0\<
+Axis press threshold
+\0\>
+Zona morta levette
+\0\<
+threshold for moving any axis/stick to consider it as being "held down"
+\0\>
+soglia entro cui un asse/levetta può essere inclinata prima che venga registrato il comando
 \0\$


### PR DESCRIPTION
There is a problem with the characters `è` and `È` in The First Encounter:

![image](https://github.com/user-attachments/assets/e3f2b8e6-9ac6-4d3c-b355-be7c7e998faf)

I don't know if it also affects `é`
